### PR TITLE
Introduce PushPublisher for remote TCP command streaming

### DIFF
--- a/rtix/ipc/node.cpp
+++ b/rtix/ipc/node.cpp
@@ -4,6 +4,7 @@
 #include "rtix/ipc/node.h"
 #include <nng/protocol/pubsub0/pub.h>
 #include <nng/protocol/pubsub0/sub.h>
+#include <nng/protocol/pipeline0/push.h>
 #include <spdlog/spdlog.h>
 #include <cstring>
 #include "rtix/core/exception.h"
@@ -201,6 +202,82 @@ std::shared_ptr<const Subscriber> Node::subscriber(
   auto it = _subs.find(channel_id);
   RTIX_THROW_IF_NOT(it != _subs.end(), "IPC", "Subscriber not found");
   return it->second;
+}
+
+PushPublisher::Config PushPublisher::Config::LoadYaml(const YAML::Node& yaml_node) {
+  PushPublisher::Config config{};
+  config.channel_id = yaml_node[CHANNEL_KEY].as<std::string>();
+  if (yaml_node["address"]) {
+    config.address = yaml_node["address"].as<std::string>();
+  }
+  if (yaml_node["send_raw_protobuf"]) {
+    config.send_raw_protobuf = yaml_node["send_raw_protobuf"].as<bool>();
+  }
+  return config;
+}
+
+PushPublisher::PushPublisher(const PushPublisher::Config& config)
+    : _channel_id(config.channel_id),
+      _address(config.address),
+      _send_raw_protobuf(config.send_raw_protobuf) {
+  if (_address.empty()) {
+    RTIX_THROW_IF_NOT(false, "IPC", "PushPublisher requires an address to dial");
+  }
+
+  int rv;
+  if ((rv = nng_push0_open(&_socket)) != 0) {
+    SPDLOG_ERROR("PushPub '{}' nng_push0_open failed ({})", _channel_id, rv);
+    RTIX_THROW_IF_NOT(false, "IPC", "Failed to start push publisher");
+  }
+  
+  // Dial the remote address (non-blocking)
+  // NNG will retry in the background if connection isn't immediately available
+  rv = nng_dial(_socket, _address.c_str(), NULL, NNG_FLAG_NONBLOCK);
+  if (rv != 0 && rv != NNG_EAGAIN) {
+    // Only fail on non-recoverable errors (not EAGAIN which means connection in progress)
+    SPDLOG_WARN("PushPub '{}' nng_dial failed ({}) - connection may be established later", _channel_id, rv);
+    // Don't throw - allow connection to be established later
+  } else if (rv == 0) {
+    SPDLOG_INFO("PushPub '{}' connected to {}", _channel_id, _address);
+  } else {
+    SPDLOG_INFO("PushPub '{}' dialing {} (connection in progress)", _channel_id, _address);
+  }
+}
+
+PushPublisher::~PushPublisher() {
+  nng_close(_socket);
+}
+
+bool PushPublisher::send(const Message& msg) const {
+  int rv;
+  std::string data;
+  
+  if (_send_raw_protobuf) {
+    // Send raw protobuf serialization (for compatibility with non-RTIX receivers)
+    if (!msg.SerializeToString(&data)) {
+      SPDLOG_ERROR("PushPub '{}' failed to serialize message", _channel_id);
+      return false;
+    }
+  } else {
+    // Send wrapped in RTIX Packet format (standard RTIX behavior)
+    data = packMessage(msg);
+  }
+  
+  rv = nng_send(_socket, (void*)data.c_str(), data.length(), 0);
+  if (rv != 0) {
+    // Check for connection errors
+    if (rv == NNG_ECLOSED || rv == NNG_ECONNREFUSED || rv == NNG_ECONNRESET) {
+      SPDLOG_WARN("PushPub '{}' connection lost ({})", _channel_id, rv);
+    } else if (rv == NNG_EAGAIN) {
+      // Socket buffer full or connection still establishing - this is recoverable
+      SPDLOG_DEBUG("PushPub '{}' send temporarily failed (EAGAIN)", _channel_id);
+    } else {
+      SPDLOG_DEBUG("PushPub '{}' send failed ({})", _channel_id, rv);
+    }
+    return false;
+  }
+  SPDLOG_DEBUG("PushPub '{}' sent data", _channel_id);
+  return true;
 }
 
 }  // namespace ipc

--- a/rtix/ipc/node.h
+++ b/rtix/ipc/node.h
@@ -68,6 +68,30 @@ class Subscriber {
   nng_socket _socket;
 };
 
+/// Push publisher for sending messages to remote receivers using Push0/Pull0 protocol.
+/// Unlike Publisher which listens locally, PushPublisher can dial remote TCP addresses.
+/// Useful for sending commands to remote services that use Pull0 to receive messages.
+class PushPublisher {
+ public:
+  struct Config {
+    std::string channel_id;
+    std::string address;  // Remote address to dial (e.g., "tcp://192.168.1.100:9001")
+    bool send_raw_protobuf{false};  // If true, send raw protobuf without RTIX Packet wrapper
+
+    static Config LoadYaml(const YAML::Node& yaml_node);
+  };
+
+  PushPublisher(const Config& config);
+  virtual ~PushPublisher();
+  bool send(const Message& msg) const;
+
+ private:
+  std::string _channel_id{};
+  std::string _address{};
+  bool _send_raw_protobuf{false};
+  nng_socket _socket;
+};
+
 /// Primary interface to manage multiple pub/sub within a single process
 class Node {
  public:

--- a/rtix/ipc/node.py
+++ b/rtix/ipc/node.py
@@ -86,6 +86,63 @@ class Publisher:
         return False
 
 
+class PushPublisher:
+    """Push publisher for sending messages to remote receivers using Push0/Pull0 protocol.
+    Unlike Publisher which listens locally, PushPublisher can dial remote TCP addresses.
+    Useful for sending commands to remote services that use Pull0 to receive messages.
+    """
+
+    @dataclass
+    class Config:
+        channel_id: str
+        address: str  # Remote address to dial (e.g., "tcp://192.168.1.100:9001")
+        send_raw_protobuf: bool = False  # If true, send raw protobuf without RTIX Packet wrapper
+
+        @staticmethod
+        def LoadYaml(yaml_dict: Dict[str, Any]) -> PushPublisher.Config:
+            """Creates the config object loaded from YAML"""
+            return PushPublisher.Config(
+                channel_id=yaml_dict[CHANNEL_KEY],
+                address=yaml_dict.get("address", ""),
+                send_raw_protobuf=yaml_dict.get("send_raw_protobuf", False),
+            )
+
+    def __init__(self, config: Config):
+        """Initializes the push publisher from config"""
+        self._channel_id = config.channel_id
+        if not config.address:
+            raise ValueError("PushPublisher requires an address to dial")
+        self._address = config.address
+        self._send_raw_protobuf = config.send_raw_protobuf
+        
+        # Use Push0 protocol to dial remote address
+        self._socket = nng.Push0(dial=self._address, block_on_dial=False)
+        logging.info("Started push publisher '{}' dialing {}".format(
+            self._channel_id, self._address))
+
+    def __del__(self):
+        """Cleans up the socket"""
+        if hasattr(self, '_socket'):
+            self._socket.close()
+
+    def send(self, msg: Message) -> bool:
+        """Send the protobuf message (blocking), returns True on success"""
+        try:
+            if self._send_raw_protobuf:
+                # Send raw protobuf serialization (for compatibility with non-RTIX receivers)
+                data = msg.SerializeToString()
+            else:
+                # Send wrapped in RTIX Packet format (standard RTIX behavior)
+                data = packMessage(msg)
+            self._socket.send(data)
+            logging.debug("PushPublisher '{}' sent data".format(self._channel_id))
+            return True
+        except Exception as e:
+            logging.error("PushPublisher '{}' send failed: {}".format(
+                self._channel_id, e))
+        return False
+
+
 class Subscriber:
     """Primary interface for subscribing to messages from a channel"""
 


### PR DESCRIPTION
This MR introduces a new PushPublisher class to the RTIX IPC library in both C++ and Python. Unlike the standard RTIX Publisher (which uses the Pub/Sub protocol and listens locally), the PushPublisher utilizes the NNG Push/Pull pipeline protocol (Push0) to actively dial and connect to remote TCP addresses.